### PR TITLE
Add stickler.yml file

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,3 @@
+linters:
+  eslint:
+    config: './.eslintrc.json'


### PR DESCRIPTION
Hi @rgavinc,

In order to activate the SticklerCI to the repo, and it's only you who can do this. Kindly do the ff:

Visit [SticklerCI page](https://stickler-ci.com/repositories), you may login using your Github account. Then search for drum-root repository. For both the drum-root frontend and backend, you can simply put the switches to on. Now for both, when Stickler asks you if you want it to make a PR for the setup, just say NO :D In this particular PR of mine I already included the needed `.stickler.yml` file anyway so we don't need Stickler to do it for us.