### PR TITLE
Created sounds factory function and collated sound configuration

### DIFF
--- a/src/utils/sounds.js
+++ b/src/utils/sounds.js
@@ -1,64 +1,73 @@
-export const createMetronomeOscillator = audioCtx => {
+const configuredOscillators = {
+  metronome: {
+    gain: {
+      value: 0.5
+    },
+    frequency: {
+      value: 1983
+    },
+    type: "triangle"
+  },
+  metronomeB1: {
+    gain: {
+      value: 0.5
+    },
+    frequency: {
+      value: 440
+    },
+    type: "triangle"
+  },
+  bassDrum: {
+    frequency: {
+      value: 150
+    }
+  },
+  hiHat: {
+    frequency: {
+      value: 80
+    },
+    type: "square"
+  },
+  snare: {
+    frequency: {
+      value: 100
+    },
+    // Not standard OscillatorNode type
+    type: "highpass"
+  }
+};
+
+const oscillatorFactory = (audioCtx, options) => {
   const oscillator = audioCtx.createOscillator();
   const gainNode = audioCtx.createGain();
+
+  const { gain, ...oscillatorOptions } = options;
 
   oscillator.connect(gainNode);
   gainNode.connect(audioCtx.destination);
 
-  gainNode.gain.value = 0.5;
-  oscillator.frequency.value = 1983;
-  oscillator.type = "triangle";
-  return oscillator;
-};
-
-export const createMetronomeOscillatorB1 = audioCtx => {
-  const oscillator = audioCtx.createOscillator();
-  const gainNode = audioCtx.createGain();
-
-  oscillator.connect(gainNode);
-  gainNode.connect(audioCtx.destination);
-
-  gainNode.gain.value = 0.5;
-  oscillator.frequency.value = 440;
-  oscillator.type = "triangle";
-  return oscillator;
-};
-
-export const createBassDrumOscillator = audioCtx => {
-  const oscillator = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-
-  oscillator.connect(gain);
-  gain.connect(audioCtx.destination);
-
-  oscillator.frequency.value = 150;
-  return oscillator;
-};
-
-export const createHiHatOscillator = audioCtx => {
-  var oscillator = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-
-  oscillator.connect(gain);
-  gain.connect(audioCtx.destination);
-
-  oscillator.type = "square";
-  oscillator.frequency.value = 80;
-  return oscillator;
-};
-
-export const createSnareOscillator = audioCtx => {
-  var oscillator = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-
-  oscillator.connect(gain);
-  gain.connect(audioCtx.destination);
-
-  oscillator.type = "highpass";
-  oscillator.frequency.value = 1000;
+  if (gain) gainNode.gain.value = gain.value;
+  if (oscillatorOptions.frequency)
+    oscillator.frequency.value = oscillatorOptions.frequency.value;
+  if (oscillatorOptions.type) oscillator.type = oscillatorOptions.type;
 
   return oscillator;
 };
+
+export const createMetronomeOscillator = audioCtx =>
+  oscillatorFactory(audioCtx, configuredOscillators["metronome"]);
+
+export const createMetronomeOscillatorB1 = audioCtx =>
+  oscillatorFactory(audioCtx, configuredOscillators["metronomeB1"]);
+
+export const createBassDrumOscillator = audioCtx =>
+  oscillatorFactory(audioCtx, configuredOscillators["bassDrum"]);
+
+export const createHiHatOscillator = audioCtx =>
+  oscillatorFactory(audioCtx, configuredOscillators["hiHat"]);
+
+export const createSnareOscillator = audioCtx =>
+  oscillatorFactory(audioCtx, configuredOscillators["snare"]);
 
 export const getOscillator = (audioCtx, type) => {
   return {


### PR DESCRIPTION
Why:

The prior version of the sounds file had repetition and variance of
naming between oscillator functions. Additionally the configuration
for each oscillator was buried in the generating function for the
specific oscillator.

This change addresses the need by:
- creating a general factory function for creating an oscillator
- pulls oscillator configurations into a dictionary for easy maintenance
- identifies that "highpass" is not a standard oscillator wave type